### PR TITLE
Fix scrolling on touch action

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -77,7 +77,8 @@ pub fn puzzle_board(
             class="board"
             style={format!("width: {}; \
                             height: {}; \
-                            position: relative;",
+                            position: relative; \
+                            touch-action: none;",
                             as_unit(width*field_size),
                             as_unit(height*field_size))}
             ontouchstart={on_touch_start}


### PR DESCRIPTION
This commit prevents the page from scrolling when a touch action (like swiping) is applied to the board with a CSS property.