### PR TITLE
[Feature] Add divide and conquer solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slide-puzzle"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly"
-components = ["rustfmt", "clippy"]

--- a/src/board/utils.rs
+++ b/src/board/utils.rs
@@ -54,6 +54,15 @@ where
     Coords { row, col }
 }
 
+pub fn get_idx_from_coords<T, U>(coords: Coords<T>, width: T) -> U
+where
+    T: std::ops::Mul<Output = T>,
+    T: std::ops::Add<Output = T>,
+    U: std::convert::From<T>,
+{
+    get_idx_from_row_col(coords.row, coords.col, width)
+}
+
 /// Check if row/column coordinates are within a field defined by width/height.
 pub fn in_bounds<T, U>(row: T, col: T, width: U, height: U) -> bool
 where

--- a/src/board/utils.rs
+++ b/src/board/utils.rs
@@ -1,3 +1,9 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Coords<T> {
+    pub row: T,
+    pub col: T,
+}
+
 /// Determine the index of the empty field (`u8::MAX`) in a slice of fields.
 pub fn get_empty_field_idx(fields: &[u8]) -> usize {
     fields
@@ -36,6 +42,16 @@ where
     U: std::convert::From<T>,
 {
     row.mul(width).add(col).into()
+}
+
+pub fn get_coords_from_idx<U>(idx: U, width: U) -> Coords<U>
+where
+    U: std::ops::Div<Output = U>,
+    U: std::ops::Rem<Output = U>,
+    U: Copy,
+{
+    let (row, col) = get_row_col_from_idx(idx, width);
+    Coords { row, col }
 }
 
 /// Check if row/column coordinates are within a field defined by width/height.

--- a/src/board/utils.rs
+++ b/src/board/utils.rs
@@ -1,12 +1,9 @@
 /// Determine the index of the empty field (`u8::MAX`) in a slice of fields.
 pub fn get_empty_field_idx(fields: &[u8]) -> usize {
-    for (idx, &value) in fields.iter().enumerate() {
-        if value == u8::MAX {
-            return idx;
-        }
-    }
-
-    panic!("Could not find empty field!");
+    fields
+        .iter()
+        .position(|&field| field == u8::MAX)
+        .expect("Should have empty field as u8::MAX")
 }
 
 /// Get the left/top coordinates based on the index of a board field.
@@ -19,17 +16,16 @@ pub fn get_left_top(idx: usize, width: usize, unit_size: usize) -> (usize, usize
 }
 
 /// Get the row/column coordinates for a linear array representing a board.
-pub fn get_row_col_from_idx<T, U>(idx: T, width: T) -> (U, U)
+pub fn get_row_col_from_idx<U>(idx: U, width: U) -> (U, U)
 where
-    T: std::ops::Div<Output = T>,
-    T: std::ops::Rem<Output = T>,
-    T: Copy,
-    U: std::convert::From<T>,
+    U: std::ops::Div<Output = U>,
+    U: std::ops::Rem<Output = U>,
+    U: Copy,
 {
     let row = idx / width;
     let col = idx % width;
 
-    (row.into(), col.into())
+    (row, col)
 }
 
 /// Get the index into a linear array based on row/column coordinates.

--- a/src/slide_puzzle.rs
+++ b/src/slide_puzzle.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     expander::Expander,
     settings::SettingsBlock,
-    solver::{divide_and_conquer::solve_puzzle, optimal::find_swap_order},
+    solver::{divide_and_conquer::DacPuzzleSolver, optimal::find_swap_order},
 };
 
 #[derive(Debug)]
@@ -283,7 +283,8 @@ impl SlidePuzzle {
 
             // Calculate the solving swap sequence only when the button is
             // clicked, not on every re-render
-            let solve_sequence = solve_puzzle(&fields, width, height);
+            let mut solver = DacPuzzleSolver::new(&fields, width as i32, height as i32);
+            let solve_sequence = solver.solve_puzzle();
             log::info!("Solve sequence: {:?}", &solve_sequence);
 
             for (i, swap) in solve_sequence.into_iter().enumerate() {

--- a/src/slide_puzzle.rs
+++ b/src/slide_puzzle.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     expander::Expander,
     settings::SettingsBlock,
-    solver::find_swap_order,
+    solver::optimal::find_swap_order,
 };
 
 #[derive(Debug)]

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,6 +1,12 @@
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    sync::Arc,
+};
 
-use crate::board::{get_empty_field_idx, get_swappable_neighbours, initialize_fields};
+use crate::board::{
+    get_empty_field_idx, get_row_col_from_idx, get_swappable_neighbours, in_bounds,
+    initialize_fields,
+};
 
 pub trait AsStringHash<T> {
     fn as_string_hash(&self) -> String;
@@ -119,10 +125,155 @@ pub fn find_swap_order(fields: &[u8], width: usize, height: usize) -> Vec<(usize
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Coords<T> {
+    row: T,
+    col: T,
+}
+
+pub fn move_first_in_place(fields: &mut [u8], width: usize, height: usize, field: u8) {
+    let width = width as i32;
+    let height = height as i32;
+
+    let target_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
+    let t_idx = target_array
+        .iter()
+        .position(|&v| v == field)
+        .expect("Should have field") as i32;
+    let (t_row, t_col) = get_row_col_from_idx(t_idx, width);
+
+    let mut empty_idx = get_empty_field_idx(&fields) as i32;
+    let mut field_idx = fields.iter().position(|&v| v == field).expect("Field") as i32;
+
+    loop {
+        let (e_row, e_col) = get_row_col_from_idx(empty_idx, width);
+        let (f_row, f_col) = get_row_col_from_idx(field_idx, width);
+
+        // Identify next field between field to move and target field
+        // For the upper row, move horizontal first
+        let d_col = t_col - f_col;
+        let d_row = t_row - f_row;
+
+        let (s_row, s_col) = identify_next_step_field_horiz_first(f_row, f_col, d_row, d_col);
+
+        let moves = compute_empty_field_moves(
+            Coords {
+                row: f_row,
+                col: f_col,
+            },
+            Coords {
+                row: s_row,
+                col: s_col,
+            },
+            Coords {
+                row: e_row,
+                col: e_col,
+            },
+            width,
+            height,
+        );
+        dbg!(moves);
+        break;
+
+        // Move empty field to that field without touching the field to move
+        // or already fixed fields
+
+        // Move through swaps
+    }
+}
+
+fn identify_next_step_field_horiz_first(
+    f_row: i32,
+    f_col: i32,
+    d_row: i32,
+    d_col: i32,
+) -> (i32, i32) {
+    // Move horizontal first
+    if d_col != 0 {
+        if d_col < 0 {
+            return (f_row, f_col - 1);
+        } else {
+            return (f_row, f_col + 1);
+        }
+    }
+
+    // d_row cannot be larger than zero because it would be in the ordered
+    // block otherwise
+    assert!(d_row <= 0);
+
+    if d_row != 0 {
+        return (f_row - 1, f_col);
+    } else {
+        return (f_row, f_col);
+    }
+}
+
+fn compute_empty_field_moves(
+    field: Coords<i32>,
+    step_field: Coords<i32>,
+    empty_field: Coords<i32>,
+    width: i32,
+    height: i32,
+) -> Vec<Coords<i32>> {
+    let mut forbidden_fields = HashSet::new();
+    forbidden_fields.insert(field);
+
+    let mut parent_field = HashMap::new();
+    let mut seen_neighbours: HashSet<Coords<i32>> = HashSet::new();
+    let mut to_discover = VecDeque::from([empty_field]);
+
+    // BFS from empty field until we find the step field
+    'expansion: while let Some(next_field) = to_discover.pop_front() {
+        seen_neighbours.insert(next_field);
+        let neighbours: Vec<Coords<i32>> = {
+            [(-1, 0), (1, 0), (0, 1), (0, -1)]
+                .iter()
+                .filter_map(|(d_row, d_col)| {
+                    let neighbour = Coords {
+                        row: next_field.row + d_row,
+                        col: next_field.col + d_col,
+                    };
+                    match in_bounds(neighbour.row, neighbour.col, width, height)
+                        && !seen_neighbours.contains(&neighbour)
+                        && !forbidden_fields.contains(&neighbour)
+                    {
+                        true => Some(neighbour),
+                        false => None,
+                    }
+                })
+                .collect()
+        };
+        for neighbour in neighbours {
+            parent_field.insert(neighbour, next_field);
+            to_discover.push_back(neighbour);
+            if neighbour == step_field {
+                break 'expansion;
+            }
+        }
+    }
+
+    // Trace back path and convert to swaps
+    let mut cur_field = step_field;
+    let mut parents = vec![cur_field];
+    while cur_field != empty_field {
+        let parent = *parent_field.get(&cur_field).expect("Should have parent");
+        parents.push(parent);
+        cur_field = parent;
+    }
+    parents.reverse();
+    parents
+}
+
 #[cfg(test)]
 mod test {
 
     use super::*;
+
+    #[test]
+    fn test_move_first_in_place() {
+        let mut test_fields = vec![8, 5, 6, 1, 0, 14, 7, 2, 255, 4, 11, 9, 12, 13, 10, 3];
+        move_first_in_place(&mut test_fields, 4, 4, 0);
+    }
 
     #[test]
     fn test_find_swap_order_zero_moves() {

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -5,212 +5,212 @@ use crate::board::{
     Coords,
 };
 
-pub fn solve_puzzle(fields: &[u8], width: usize, height: usize) -> Vec<(usize, usize)> {
-    let mut fields = fields.to_owned();
-    assert_eq!(fields.len(), width * height);
-
-    let goal_array = initialize_fields(width * height);
-
-    let width = width as i32;
-    let height = height as i32;
-
-    let mut swaps = Vec::new();
-
-    let mut forbidden_fields = HashSet::new();
-
-    let mut current_row = 0;
-    for col in 0..width - 1 {
-        let cur_coords = Coords {
-            row: current_row,
-            col: col,
-        };
-        let cur_idx: i32 = get_idx_from_coords(cur_coords, width);
-        if let (Some(cur_field), Some(goal_field)) = (
-            fields.get(cur_idx as usize),
-            goal_array.get(cur_idx as usize),
-        ) {
-            if cur_field != goal_field {
-                let goal_idx = goal_array
-                    .iter()
-                    .position(|&v| v == *goal_field)
-                    .expect("Should have field") as i32;
-                let field_idx = fields
-                    .iter()
-                    .position(|&v| v == *goal_field)
-                    .expect("Field") as i32;
-                let iteration_swaps = compute_swaps_to_goal_pos(
-                    &mut fields,
-                    &forbidden_fields,
-                    width,
-                    height,
-                    field_idx,
-                    goal_idx,
-                );
-
-                swaps.extend(iteration_swaps);
-            }
-            forbidden_fields.insert(cur_coords);
-        }
-    }
-
-    // Solve complicated part now
-
-    swaps
-}
-
-/// Move a field into its goal place.
-pub fn compute_swaps_to_goal_pos(
-    fields: &mut [u8],
-    forbidden_fields: &HashSet<Coords<i32>>,
+pub struct DacPuzzleSolver {
+    fields: Vec<u8>,
+    forbidden_fields: HashSet<Coords<i32>>,
     width: i32,
     height: i32,
-    mut field_idx: i32,
-    goal_idx: i32,
-) -> Vec<(usize, usize)> {
-    // let goal_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
-    let goal_pos = get_coords_from_idx(goal_idx, width);
+}
 
-    let mut swaps = Vec::new();
+impl DacPuzzleSolver {
+    pub fn new(fields: &[u8], width: i32, height: i32) -> Self {
+        assert_eq!(fields.len() as i32, width * height);
 
-    // Determine initial indices. We will overwrite the values with every
-    // iteration of the loop.
-    let mut empty_idx = get_empty_field_idx(&fields) as i32;
-
-    // Determine the next target on the way to the goal position for the field
-    // which we are moving. One iteration of the loop moves the empty field to
-    // this target and then swaps the field with the empty field.
-    loop {
-        let empty_field = get_coords_from_idx(empty_idx, width);
-        let field_coords = get_coords_from_idx(field_idx, width);
-
-        // Identify next target field between field to move and goal field
-        // TODO: Abstract
-        let delta_coords = Coords {
-            row: goal_pos.row - field_coords.row,
-            col: goal_pos.col - field_coords.col,
-        };
-
-        // Check if the field we are moving reached the goal field and return
-        // swaps if so.
-        if delta_coords == (Coords { row: 0, col: 0 }) {
-            return swaps;
-        }
-
-        // For the upper row, move horizontal first
-        let target_coords = identify_next_step_field_horiz_first(field_coords, delta_coords);
-
-        // Compute the moves required to bring the empty field to the target
-        // field position.
-        let moves = compute_empty_field_moves(
-            field_coords,
-            &forbidden_fields,
-            target_coords,
-            empty_field,
+        Self {
+            fields: fields.to_owned(),
+            forbidden_fields: HashSet::new(),
             width,
             height,
-        );
-
-        // Convert the moves to swaps
-        let mut iteration_swaps = Vec::new();
-        for step in moves {
-            let step_idx: i32 = get_idx_from_coords(step, width);
-            let swap = (empty_idx as usize, step_idx as usize);
-            empty_idx = step_idx;
-            iteration_swaps.push(swap);
         }
-        // Include swapping the empty field and the field we are moving
-        let tmp = empty_idx;
-        empty_idx = field_idx;
-        field_idx = tmp;
-        iteration_swaps.push((empty_idx as usize, field_idx as usize));
-
-        // Perform swaps to prepare next iteration
-        for swap in iteration_swaps.iter() {
-            fields.swap(swap.0, swap.1);
-        }
-
-        // Add swaps to overall swaps
-        swaps.extend(iteration_swaps);
     }
-}
 
-/// Compute the path of shifting the empty field.
-///
-/// Fields that may not be moved/touched are specified in `forbidden_fields`.
-fn compute_empty_field_moves(
-    field: Coords<i32>,
-    forbidden_fields: &HashSet<Coords<i32>>,
-    target_field: Coords<i32>,
-    empty_field: Coords<i32>,
-    width: i32,
-    height: i32,
-) -> Vec<Coords<i32>> {
-    // Look-up of parents of fields. This enables us to trace back the path to
-    // our empty field once we reach the target field.
-    let mut parent_field = HashMap::new();
+    pub fn solve_puzzle(&mut self) -> Vec<(usize, usize)> {
+        let goal_array = initialize_fields((self.width * self.height) as usize);
 
-    // Set of seen fields and queue of fields to explore for Dijkstra algorithm.
-    let mut seen_neighbours: HashSet<Coords<i32>> = HashSet::new();
-    let mut to_discover = VecDeque::from([empty_field]);
+        let mut swaps = Vec::new();
 
-    // Run Dijkstra (excluding forbidden fields) from empty field until we find
-    // the target field.
-    'expansion: while let Some(cur_field) = to_discover.pop_front() {
-        // Mark neighbour as seen/processed for Dijkstra. We do this before
-        // looping through the neighbours so that we can break as soon as we
-        // see the target field.
-        seen_neighbours.insert(cur_field);
+        let mut current_row = 0;
+        for col in 0..self.width - 1 {
+            let cur_coords = Coords {
+                row: current_row,
+                col,
+            };
+            let cur_idx: i32 = get_idx_from_coords(cur_coords, self.width);
+            if let (Some(cur_field), Some(goal_field)) = (
+                self.fields.get(cur_idx as usize),
+                goal_array.get(cur_idx as usize),
+            ) {
+                if cur_field != goal_field {
+                    let goal_idx = goal_array
+                        .iter()
+                        .position(|&v| v == *goal_field)
+                        .expect("Should have field") as i32;
+                    let field_idx = self
+                        .fields
+                        .iter()
+                        .position(|&v| v == *goal_field)
+                        .expect("Field") as i32;
+                    let iteration_swaps = self.compute_swaps_to_goal_pos(field_idx, goal_idx);
 
-        // Identify neighbours
-        let neighbours: Vec<Coords<i32>> = {
-            [(-1, 0), (1, 0), (0, 1), (0, -1)]
-                .iter()
-                .filter_map(|(d_row, d_col)| {
-                    let neighbour = Coords {
-                        row: cur_field.row + d_row,
-                        col: cur_field.col + d_col,
-                    };
-                    // Filter out fields which are outside of the board, already
-                    // processed or in the forbidden set.
-                    match in_bounds(neighbour.row, neighbour.col, width, height)
-                        && !seen_neighbours.contains(&neighbour)
-                        && !forbidden_fields.contains(&neighbour)
-                        && neighbour != field
-                    {
-                        true => Some(neighbour),
-                        false => None,
-                    }
-                })
-                .collect()
-        };
-
-        // Add the current field as parent for all neighbours and queue them
-        // to be processed.
-        for neighbour in neighbours {
-            parent_field.insert(neighbour, cur_field);
-            to_discover.push_back(neighbour);
-            // If our target field is among the neighbours, terminate the
-            // Dijkstra search.
-            if neighbour == target_field {
-                break 'expansion;
+                    swaps.extend(iteration_swaps);
+                }
+                self.forbidden_fields.insert(cur_coords);
             }
         }
+
+        // Solve complicated part now
+
+        swaps
     }
 
-    // Trace back path from the target field to the beginning
-    let mut cur_field = target_field;
-    let mut parents = vec![cur_field];
-    while cur_field != empty_field {
-        cur_field = *parent_field.get(&cur_field).expect("Should have parent");
-        parents.push(cur_field);
+    fn get_corner_swaps_horizontally() {
+        // Move last piece to place two rows below
+        // Move empty field to one row below
+        // Do fixed swaps
     }
 
-    // Remove the empty field itself as move
-    parents.pop();
+    /// Move a field given its index to a goal index.
+    fn compute_swaps_to_goal_pos(
+        &mut self,
+        mut field_idx: i32,
+        goal_idx: i32,
+    ) -> Vec<(usize, usize)> {
+        // let goal_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
+        let goal_pos = get_coords_from_idx(goal_idx, self.width);
 
-    // Reverse to start from the beginning and return
-    parents.reverse();
-    parents
+        let mut swaps = Vec::new();
+
+        // Determine initial indices. We will overwrite the values with every
+        // iteration of the loop.
+        let mut empty_idx = get_empty_field_idx(&self.fields) as i32;
+
+        // Determine the next target on the way to the goal position for the field
+        // which we are moving. One iteration of the loop moves the empty field to
+        // this target and then swaps the field with the empty field.
+        loop {
+            let empty_field = get_coords_from_idx(empty_idx, self.width);
+            let field_coords = get_coords_from_idx(field_idx, self.width);
+
+            // Identify next target field between field to move and goal field
+            // TODO: Abstract
+            let delta_coords = Coords {
+                row: goal_pos.row - field_coords.row,
+                col: goal_pos.col - field_coords.col,
+            };
+
+            // Check if the field we are moving reached the goal field and return
+            // swaps if so.
+            if delta_coords == (Coords { row: 0, col: 0 }) {
+                return swaps;
+            }
+
+            // For the upper row, move horizontal first
+            let target_coords = identify_next_step_field_horiz_first(field_coords, delta_coords);
+
+            // Compute the moves required to bring the empty field to the target
+            // field position.
+            let moves = self.compute_empty_field_moves(field_coords, target_coords, empty_field);
+
+            // Convert the moves to swaps
+            let mut iteration_swaps = Vec::new();
+            for step in moves {
+                let step_idx: i32 = get_idx_from_coords(step, self.width);
+                let swap = (empty_idx as usize, step_idx as usize);
+                empty_idx = step_idx;
+                iteration_swaps.push(swap);
+            }
+            // Include swapping the empty field and the field we are moving
+            let tmp = empty_idx;
+            empty_idx = field_idx;
+            field_idx = tmp;
+            iteration_swaps.push((empty_idx as usize, field_idx as usize));
+
+            // Perform swaps to prepare next iteration
+            for swap in iteration_swaps.iter() {
+                self.fields.swap(swap.0, swap.1);
+            }
+
+            // Add swaps to overall swaps
+            swaps.extend(iteration_swaps);
+        }
+    }
+
+    /// Compute the path of shifting the empty field.
+    ///
+    /// Fields that may not be moved/touched are specified in `forbidden_fields`.
+    fn compute_empty_field_moves(
+        &self,
+        field: Coords<i32>,
+        target_field: Coords<i32>,
+        empty_field: Coords<i32>,
+    ) -> Vec<Coords<i32>> {
+        // Look-up of parents of fields. This enables us to trace back the path to
+        // our empty field once we reach the target field.
+        let mut parent_field = HashMap::new();
+
+        // Set of seen fields and queue of fields to explore for Dijkstra algorithm.
+        let mut seen_neighbours: HashSet<Coords<i32>> = HashSet::new();
+        let mut to_discover = VecDeque::from([empty_field]);
+
+        // Run Dijkstra (excluding forbidden fields) from empty field until we find
+        // the target field.
+        'expansion: while let Some(cur_field) = to_discover.pop_front() {
+            // Mark neighbour as seen/processed for Dijkstra. We do this before
+            // looping through the neighbours so that we can break as soon as we
+            // see the target field.
+            seen_neighbours.insert(cur_field);
+
+            // Identify neighbours
+            let neighbours: Vec<Coords<i32>> = {
+                [(-1, 0), (1, 0), (0, 1), (0, -1)]
+                    .iter()
+                    .filter_map(|(d_row, d_col)| {
+                        let neighbour = Coords {
+                            row: cur_field.row + d_row,
+                            col: cur_field.col + d_col,
+                        };
+                        // Filter out fields which are outside of the board, already
+                        // processed or in the forbidden set.
+                        match in_bounds(neighbour.row, neighbour.col, self.width, self.height)
+                            && !seen_neighbours.contains(&neighbour)
+                            && !self.forbidden_fields.contains(&neighbour)
+                            && neighbour != field
+                        {
+                            true => Some(neighbour),
+                            false => None,
+                        }
+                    })
+                    .collect()
+            };
+
+            // Add the current field as parent for all neighbours and queue them
+            // to be processed.
+            for neighbour in neighbours {
+                parent_field.insert(neighbour, cur_field);
+                to_discover.push_back(neighbour);
+                // If our target field is among the neighbours, terminate the
+                // Dijkstra search.
+                if neighbour == target_field {
+                    break 'expansion;
+                }
+            }
+        }
+
+        // Trace back path from the target field to the beginning
+        let mut cur_field = target_field;
+        let mut parents = vec![cur_field];
+        while cur_field != empty_field {
+            cur_field = *parent_field.get(&cur_field).expect("Should have parent");
+            parents.push(cur_field);
+        }
+
+        // Remove the empty field itself as move
+        parents.pop();
+
+        // Reverse to start from the beginning and return
+        parents.reverse();
+        parents
+    }
 }
 
 fn identify_next_step_field_horiz_first(
@@ -257,17 +257,9 @@ mod test {
     #[test]
     fn test_move_first_in_place() {
         let mut test_fields = vec![8, 5, 6, 1, 14, 4, 7, 2, 0, 13, 11, 9, 255, 12, 10, 3];
-        let forbidden_fields = HashSet::from([Coords { row: 0, col: 0 }]);
-        let goal_idx = 0;
-        let field_idx = test_fields.iter().position(|&v| v == 0).expect("Field") as i32;
-        let swaps = compute_swaps_to_goal_pos(
-            &mut test_fields,
-            &forbidden_fields,
-            4,
-            4,
-            field_idx,
-            goal_idx,
-        );
+
+        let mut solver = DacPuzzleSolver::new(&test_fields, 4, 4);
+        let swaps = solver.solve_puzzle();
 
         for swap in swaps {
             test_fields.swap(swap.0, swap.1);

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -1,54 +1,41 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::board::{get_empty_field_idx, get_row_col_from_idx, in_bounds};
+use crate::board::{
+    get_coords_from_idx, get_empty_field_idx, get_row_col_from_idx, in_bounds, Coords,
+};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Coords<T> {
-    row: T,
-    col: T,
-}
-
-pub fn move_first_in_place(fields: &mut [u8], width: usize, height: usize, field: u8) {
+pub fn move_first_in_place(fields: &mut [u8], width: usize, height: usize, field_value: u8) {
     let width = width as i32;
     let height = height as i32;
 
-    let target_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
-    let t_idx = target_array
+    let goal_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
+    let g_idx = goal_array
         .iter()
-        .position(|&v| v == field)
+        .position(|&v| v == field_value)
         .expect("Should have field") as i32;
-    let (t_row, t_col) = get_row_col_from_idx(t_idx, width);
+    let goal_coords = get_coords_from_idx(g_idx, width);
 
     let mut empty_idx = get_empty_field_idx(&fields) as i32;
-    let mut field_idx = fields.iter().position(|&v| v == field).expect("Field") as i32;
+    let mut field_idx = fields
+        .iter()
+        .position(|&v| v == field_value)
+        .expect("Field") as i32;
 
     loop {
-        let (e_row, e_col) = get_row_col_from_idx(empty_idx, width);
-        let (f_row, f_col) = get_row_col_from_idx(field_idx, width);
+        let empty_field = get_coords_from_idx(empty_idx, width);
+        let field_coords = get_coords_from_idx(field_idx, width);
 
-        // Identify next field between field to move and target field
+        // Identify next field between field to move and goal field
         // For the upper row, move horizontal first
-        let d_col = t_col - f_col;
-        let d_row = t_row - f_row;
+        let delta_coords = Coords {
+            row: goal_coords.row - field_coords.row,
+            col: goal_coords.col - field_coords.col,
+        };
 
-        let (s_row, s_col) = identify_next_step_field_horiz_first(f_row, f_col, d_row, d_col);
+        let target_coords = identify_next_step_field_horiz_first(field_coords, delta_coords);
 
-        let moves = compute_empty_field_moves(
-            Coords {
-                row: f_row,
-                col: f_col,
-            },
-            Coords {
-                row: s_row,
-                col: s_col,
-            },
-            Coords {
-                row: e_row,
-                col: e_col,
-            },
-            width,
-            height,
-        );
+        let moves =
+            compute_empty_field_moves(field_coords, target_coords, empty_field, width, height);
         dbg!(moves);
         break;
 
@@ -60,34 +47,47 @@ pub fn move_first_in_place(fields: &mut [u8], width: usize, height: usize, field
 }
 
 fn identify_next_step_field_horiz_first(
-    f_row: i32,
-    f_col: i32,
-    d_row: i32,
-    d_col: i32,
-) -> (i32, i32) {
+    field_coords: Coords<i32>,
+    delta_coords: Coords<i32>,
+) -> Coords<i32> {
     // Move horizontal first
-    if d_col != 0 {
-        if d_col < 0 {
-            return (f_row, f_col - 1);
+    if delta_coords.col != 0 {
+        if delta_coords.col < 0 {
+            return Coords {
+                row: field_coords.row,
+                col: field_coords.col - 1,
+            };
         } else {
-            return (f_row, f_col + 1);
+            return Coords {
+                row: field_coords.row,
+                col: field_coords.col + 1,
+            };
         }
     }
 
-    // d_row cannot be larger than zero because it would be in the ordered
+    // delta_coords.row cannot be larger than zero because it would be in the ordered
     // block otherwise
-    assert!(d_row <= 0);
+    assert!(delta_coords.row <= 0);
 
-    if d_row != 0 {
-        return (f_row - 1, f_col);
+    if delta_coords.row != 0 {
+        return Coords {
+            row: field_coords.row - 1,
+            col: field_coords.col,
+        };
     } else {
-        return (f_row, f_col);
+        return Coords {
+            row: field_coords.row,
+            col: field_coords.col,
+        };
     }
 }
 
+/// Compute the path of shifting the empty field.
+///
+/// Fields that may not be moved/touched are specified in `forbidden_fields`.
 fn compute_empty_field_moves(
     field: Coords<i32>,
-    step_field: Coords<i32>,
+    target_field: Coords<i32>,
     empty_field: Coords<i32>,
     width: i32,
     height: i32,
@@ -95,21 +95,33 @@ fn compute_empty_field_moves(
     let mut forbidden_fields = HashSet::new();
     forbidden_fields.insert(field);
 
+    // Look-up of parents of fields. This enables us to trace back the path to
+    // our empty field once we reach the target field.
     let mut parent_field = HashMap::new();
+
+    // Set of seen fields and queue of fields to explore for Dijkstra algorithm.
     let mut seen_neighbours: HashSet<Coords<i32>> = HashSet::new();
     let mut to_discover = VecDeque::from([empty_field]);
 
-    // BFS from empty field until we find the step field
-    'expansion: while let Some(next_field) = to_discover.pop_front() {
-        seen_neighbours.insert(next_field);
+    // Run Dijkstra (excluding forbidden fields) from empty field until we find
+    // the target field.
+    'expansion: while let Some(cur_field) = to_discover.pop_front() {
+        // Mark neighbour as seen/processed for Dijkstra. We do this before
+        // looping through the neighbours so that we can break as soon as we
+        // see the target field.
+        seen_neighbours.insert(cur_field);
+
+        // Identify neighbours
         let neighbours: Vec<Coords<i32>> = {
             [(-1, 0), (1, 0), (0, 1), (0, -1)]
                 .iter()
                 .filter_map(|(d_row, d_col)| {
                     let neighbour = Coords {
-                        row: next_field.row + d_row,
-                        col: next_field.col + d_col,
+                        row: cur_field.row + d_row,
+                        col: cur_field.col + d_col,
                     };
+                    // Filter out fields which are outside of the board, already
+                    // processed or in the forbidden set.
                     match in_bounds(neighbour.row, neighbour.col, width, height)
                         && !seen_neighbours.contains(&neighbour)
                         && !forbidden_fields.contains(&neighbour)
@@ -120,23 +132,29 @@ fn compute_empty_field_moves(
                 })
                 .collect()
         };
+
+        // Add the current field as parent for all neighbours and queue them
+        // to be processed.
         for neighbour in neighbours {
-            parent_field.insert(neighbour, next_field);
+            parent_field.insert(neighbour, cur_field);
             to_discover.push_back(neighbour);
-            if neighbour == step_field {
+            // If our target field is among the neighbours, terminate the
+            // Dijkstra search.
+            if neighbour == target_field {
                 break 'expansion;
             }
         }
     }
 
-    // Trace back path and convert to swaps
-    let mut cur_field = step_field;
+    // Trace back path from the target field to the beginning
+    let mut cur_field = target_field;
     let mut parents = vec![cur_field];
     while cur_field != empty_field {
-        let parent = *parent_field.get(&cur_field).expect("Should have parent");
-        parents.push(parent);
-        cur_field = parent;
+        cur_field = *parent_field.get(&cur_field).expect("Should have parent");
+        parents.push(cur_field);
     }
+
+    // Reverse to start from the beginning and return
     parents.reverse();
     parents
 }

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -88,7 +88,7 @@ impl DacPuzzleSolver {
         };
         let goal_idx = get_idx_from_coords(goal_pos, self.width);
         let mut swaps = self.compute_swaps_to_goal_pos(field_idx, goal_idx);
-        let mut empty_idx = swaps.last().expect("Last").0 as i32;
+        let mut empty_idx = get_empty_field_idx(&self.fields) as i32;
         let empty_field = get_coords_from_idx(empty_idx, self.width);
 
         let empty_target_pos = Coords {
@@ -107,8 +107,73 @@ impl DacPuzzleSolver {
         }
 
         // Do fixed swaps
+        let moves = self.get_fixed_corner_moves_horizontally(empty_target_pos);
+        for step in moves {
+            let step_idx: i32 = get_idx_from_coords(step, self.width);
+            let swap = (empty_idx as usize, step_idx as usize);
+            empty_idx = step_idx;
+            swaps.push(swap);
+            self.fields.swap(swap.0, swap.1)
+        }
 
         swaps
+    }
+
+    fn get_fixed_corner_moves_horizontally(&self, empty_pos: Coords<i32>) -> Vec<Coords<i32>> {
+        // Assumes this setup e.g. for row 0:
+        // 0 1 2 X   0 1 2     0 1   2   0 1 X 2   0 1 X 2   0 1 X 2   0 1 X 2
+        // X X X     X X X X   X X X X   X X   X   X X X     X X X 3   X X X 3
+        // X X X 3   X X X 3   X X X 3   X X X 3   X X X 3   X X X     X X   X
+        // X X X X   X X X X   X X X X   X X X X   X X X X   X X X X   X X X X
+        //
+        //   ->
+        //
+        // 0 1 X 2   0 1   2   0 1 2     0 1 2 3
+        // X X   3   X X X 3   X X X 3   X X X
+        // X X X X   X X X X   X X X X   X X X X
+        // X X X X   X X X X   X X X X   X X X X
+        vec![
+            Coords {
+                row: empty_pos.row - 1,
+                col: empty_pos.col,
+            },
+            Coords {
+                row: empty_pos.row - 1,
+                col: empty_pos.col - 1,
+            },
+            Coords {
+                row: empty_pos.row,
+                col: empty_pos.col - 1,
+            },
+            Coords {
+                row: empty_pos.row,
+                col: empty_pos.col,
+            },
+            Coords {
+                row: empty_pos.row + 1,
+                col: empty_pos.col,
+            },
+            Coords {
+                row: empty_pos.row + 1,
+                col: empty_pos.col - 1,
+            },
+            Coords {
+                row: empty_pos.row,
+                col: empty_pos.col - 1,
+            },
+            Coords {
+                row: empty_pos.row - 1,
+                col: empty_pos.col - 1,
+            },
+            Coords {
+                row: empty_pos.row - 1,
+                col: empty_pos.col,
+            },
+            Coords {
+                row: empty_pos.row,
+                col: empty_pos.col,
+            },
+        ]
     }
 
     /// Move a field given its index to a goal index.

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -1,3 +1,8 @@
+//! Divide and conquer puzzle solver
+//!
+//! See also:
+//! https://www.kopf.com.br/kaplof/how-to-solve-any-slide-puzzle-regardless-of-its-size/
+//!
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::board::{

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -57,7 +57,7 @@ impl DacPuzzleSolver {
         let mut working_col = 0;
 
         'row_col_loop: loop {
-            if self.width - working_col <= 2 || self.height - working_row <= 2 {
+            if self.width - working_col < 2 || self.height - working_row < 2 {
                 break 'row_col_loop;
             }
 
@@ -98,9 +98,6 @@ impl DacPuzzleSolver {
 
                     // Prepare next iteration step
                     working_row += 1;
-
-                    // TODO: Remove
-                    break 'row_col_loop;
                 }
                 SolverPhase::Column => {
                     // Solve fields in the column starting at `working_row`
@@ -135,8 +132,12 @@ impl DacPuzzleSolver {
                             phase,
                         );
                     }
+
                     // Prepare next iteration step
                     working_col += 1;
+
+                    // TODO: Remove
+                    break 'row_col_loop;
                 }
             }
 
@@ -172,8 +173,7 @@ impl DacPuzzleSolver {
             }
 
             // For the upper row, move horizontal first
-            let target_coords =
-                identify_next_step_field_horiz_first(goal_value_pos, delta_coords, phase);
+            let target_coords = identify_next_step_field(goal_value_pos, delta_coords, phase);
 
             // Compute the moves required to bring the empty field to the target
             // field position and apply them.
@@ -207,7 +207,7 @@ impl DacPuzzleSolver {
         };
         let empty_field_target_pos = Coords {
             // The empty field should end up in the same column but one row
-            // above the currently targeted field
+            // below the final goal position/one row above the goal position
             row: goal_pos.row - 1,
             col: goal_pos.col,
         };
@@ -357,7 +357,7 @@ impl DacPuzzleSolver {
     }
 }
 
-fn identify_next_step_field_horiz_first(
+fn identify_next_step_field(
     field_coords: Coords<i32>,
     delta_coords: Coords<i32>,
     phase: SolverPhase,
@@ -398,39 +398,6 @@ fn identify_next_step_field_horiz_first(
     }
 
     field_coords
-    // // Move horizontal first
-    // if delta_coords.col != 0 {
-    //     if delta_coords.col < 0 {
-    //         return Coords {
-    //             row: field_coords.row,
-    //             col: field_coords.col - 1,
-    //         };
-    //     } else {
-    //         return Coords {
-    //             row: field_coords.row,
-    //             col: field_coords.col + 1,
-    //         };
-    //     }
-    // }
-
-    // if delta_coords.row != 0 {
-    //     if delta_coords.row < 0 {
-    //         return Coords {
-    //             row: field_coords.row - 1,
-    //             col: field_coords.col,
-    //         };
-    //     } else {
-    //         return Coords {
-    //             row: field_coords.row + 1,
-    //             col: field_coords.col,
-    //         };
-    //     }
-    // } else {
-    //     return Coords {
-    //         row: field_coords.row,
-    //         col: field_coords.col,
-    //     };
-    // }
 }
 
 /// Get the index of a value in a slice.

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -77,6 +77,11 @@ impl DacPuzzleSolver {
         field_goal_pos: Coords<i32>,
     ) -> Vec<(usize, usize)> {
         // Move last piece to place two rows below
+
+        // May need a shortcut for a setting like this:
+        // 0 1
+        // X X 2
+        // X X X
         let field_idx = self
             .fields
             .iter()
@@ -107,7 +112,7 @@ impl DacPuzzleSolver {
         }
 
         // Do fixed swaps
-        let moves = self.get_fixed_corner_moves_horizontally(empty_target_pos);
+        let moves = get_fixed_corner_moves_horizontally(empty_target_pos);
         for step in moves {
             let step_idx: i32 = get_idx_from_coords(step, self.width);
             let swap = (empty_idx as usize, step_idx as usize);
@@ -117,63 +122,6 @@ impl DacPuzzleSolver {
         }
 
         swaps
-    }
-
-    fn get_fixed_corner_moves_horizontally(&self, empty_pos: Coords<i32>) -> Vec<Coords<i32>> {
-        // Assumes this setup e.g. for row 0:
-        // 0 1 2 X   0 1 2     0 1   2   0 1 X 2   0 1 X 2   0 1 X 2   0 1 X 2
-        // X X X     X X X X   X X X X   X X   X   X X X     X X X 3   X X X 3
-        // X X X 3   X X X 3   X X X 3   X X X 3   X X X 3   X X X     X X   X
-        // X X X X   X X X X   X X X X   X X X X   X X X X   X X X X   X X X X
-        //
-        //   ->
-        //
-        // 0 1 X 2   0 1   2   0 1 2     0 1 2 3
-        // X X   3   X X X 3   X X X 3   X X X
-        // X X X X   X X X X   X X X X   X X X X
-        // X X X X   X X X X   X X X X   X X X X
-        vec![
-            Coords {
-                row: empty_pos.row - 1,
-                col: empty_pos.col,
-            },
-            Coords {
-                row: empty_pos.row - 1,
-                col: empty_pos.col - 1,
-            },
-            Coords {
-                row: empty_pos.row,
-                col: empty_pos.col - 1,
-            },
-            Coords {
-                row: empty_pos.row,
-                col: empty_pos.col,
-            },
-            Coords {
-                row: empty_pos.row + 1,
-                col: empty_pos.col,
-            },
-            Coords {
-                row: empty_pos.row + 1,
-                col: empty_pos.col - 1,
-            },
-            Coords {
-                row: empty_pos.row,
-                col: empty_pos.col - 1,
-            },
-            Coords {
-                row: empty_pos.row - 1,
-                col: empty_pos.col - 1,
-            },
-            Coords {
-                row: empty_pos.row - 1,
-                col: empty_pos.col,
-            },
-            Coords {
-                row: empty_pos.row,
-                col: empty_pos.col,
-            },
-        ]
     }
 
     /// Move a field given its index to a goal index.
@@ -359,6 +307,63 @@ fn identify_next_step_field_horiz_first(
     }
 }
 
+fn get_fixed_corner_moves_horizontally(empty_pos: Coords<i32>) -> Vec<Coords<i32>> {
+    // Assumes this setup e.g. for row 0:
+    // 0 1 2 X   0 1 2     0 1   2   0 1 X 2   0 1 X 2   0 1 X 2   0 1 X 2
+    // X X X     X X X X   X X X X   X X   X   X X X     X X X 3   X X X 3
+    // X X X 3   X X X 3   X X X 3   X X X 3   X X X 3   X X X     X X   X
+    // X X X X   X X X X   X X X X   X X X X   X X X X   X X X X   X X X X
+    //
+    //   ->
+    //
+    // 0 1 X 2   0 1   2   0 1 2     0 1 2 3
+    // X X   3   X X X 3   X X X 3   X X X
+    // X X X X   X X X X   X X X X   X X X X
+    // X X X X   X X X X   X X X X   X X X X
+    vec![
+        Coords {
+            row: empty_pos.row - 1,
+            col: empty_pos.col,
+        },
+        Coords {
+            row: empty_pos.row - 1,
+            col: empty_pos.col - 1,
+        },
+        Coords {
+            row: empty_pos.row,
+            col: empty_pos.col - 1,
+        },
+        Coords {
+            row: empty_pos.row,
+            col: empty_pos.col,
+        },
+        Coords {
+            row: empty_pos.row + 1,
+            col: empty_pos.col,
+        },
+        Coords {
+            row: empty_pos.row + 1,
+            col: empty_pos.col - 1,
+        },
+        Coords {
+            row: empty_pos.row,
+            col: empty_pos.col - 1,
+        },
+        Coords {
+            row: empty_pos.row - 1,
+            col: empty_pos.col - 1,
+        },
+        Coords {
+            row: empty_pos.row - 1,
+            col: empty_pos.col,
+        },
+        Coords {
+            row: empty_pos.row,
+            col: empty_pos.col,
+        },
+    ]
+}
+
 #[cfg(test)]
 mod test {
 
@@ -380,9 +385,9 @@ mod test {
 
     #[test]
     fn test_second() {
-        let mut test_fields = vec![3, 2, 255, 6, 5, 0, 7, 1, 4];
+        let mut test_fields = vec![2, 1, 5, 3, 0, 7, 255, 6, 4];
 
-        let mut solver = DacPuzzleSolver::new(&test_fields, 4, 4);
+        let mut solver = DacPuzzleSolver::new(&test_fields, 3, 3);
         let swaps = solver.solve_puzzle();
 
         for swap in swaps {

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -87,8 +87,7 @@ impl DacPuzzleSolver {
         };
         let goal_idx = get_idx_from_coords(goal_pos, self.width);
         let mut swaps = self.compute_swaps_to_goal_pos(field_idx, goal_idx);
-        let mut empty_idx = get_empty_field_idx(&self.fields) as i32;
-        let empty_field = get_coords_from_idx(empty_idx, self.width);
+        let empty_field = get_coords_from_idx(self.empty_field_idx, self.width);
 
         let empty_target_pos = Coords {
             row: goal_pos.row - 1,
@@ -97,23 +96,11 @@ impl DacPuzzleSolver {
 
         // Move empty field to one row below
         let moves = self.compute_empty_field_moves(goal_pos, empty_target_pos, empty_field);
-        for step in moves {
-            let step_idx: i32 = get_idx_from_coords(step, self.width);
-            let swap = (empty_idx as usize, step_idx as usize);
-            empty_idx = step_idx;
-            swaps.push(swap);
-            self.fields.swap(swap.0, swap.1)
-        }
+        swaps.extend(self.apply_empty_field_moves(&moves));
 
         // Do fixed swaps
         let moves = get_fixed_corner_moves_horizontally(empty_target_pos);
-        for step in moves {
-            let step_idx: i32 = get_idx_from_coords(step, self.width);
-            let swap = (empty_idx as usize, step_idx as usize);
-            empty_idx = step_idx;
-            swaps.push(swap);
-            self.fields.swap(swap.0, swap.1)
-        }
+        swaps.extend(self.apply_empty_field_moves(&moves));
 
         swaps
     }
@@ -145,10 +132,6 @@ impl DacPuzzleSolver {
         let goal_pos = get_coords_from_idx(goal_idx, self.width);
 
         let mut swaps = Vec::new();
-
-        // Determine initial indices. We will overwrite the values with every
-        // iteration of the loop.
-        // let mut empty_idx = get_empty_field_idx(&self.fields) as i32;
 
         // Determine the next target on the way to the goal position for the field
         // which we are moving. One iteration of the loop moves the empty field to
@@ -186,7 +169,6 @@ impl DacPuzzleSolver {
             let tmp = self.empty_field_idx;
             self.empty_field_idx = field_idx;
             field_idx = tmp;
-            // iteration_swaps.push((empty_idx as usize, field_idx as usize));
         }
     }
 

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -1,8 +1,32 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::board::{
-    get_coords_from_idx, get_empty_field_idx, get_idx_from_coords, in_bounds, Coords,
+    get_coords_from_idx, get_empty_field_idx, get_idx_from_coords, in_bounds, initialize_fields,
+    Coords,
 };
+
+pub fn solve_puzzle(fields: &[u8], width: usize, height: usize) -> Vec<(usize, usize)> {
+    let mut fields = fields.to_owned();
+    let goal_array = initialize_fields(width * height);
+
+    let mut swaps = Vec::new();
+
+    for i in 0..width - 2 {
+        if let (Some(field), Some(goal_field)) = (fields.get(i), goal_array.get(i)) {
+            if field != goal_field {
+                let iteration_swaps =
+                    compute_swaps_to_goal_pos(&fields, width, height, *goal_field);
+                for swap in iteration_swaps.iter() {
+                    fields.swap(swap.0, swap.1);
+                }
+
+                swaps.extend(iteration_swaps);
+            }
+        }
+    }
+
+    swaps
+}
 
 /// Move a field into its goal place.
 pub fn compute_swaps_to_goal_pos(
@@ -59,7 +83,7 @@ pub fn compute_swaps_to_goal_pos(
         // field position.
         let moves =
             compute_empty_field_moves(field_coords, target_coords, empty_field, width, height);
-        dbg!(&moves);
+        // dbg!(&moves);
 
         // Convert the moves to swaps
         let mut iteration_swaps = Vec::new();
@@ -74,7 +98,7 @@ pub fn compute_swaps_to_goal_pos(
         empty_idx = field_idx;
         field_idx = tmp;
         iteration_swaps.push((empty_idx as usize, field_idx as usize));
-        dbg!(&iteration_swaps);
+        // dbg!(&iteration_swaps);
 
         // Perform swaps to prepare next iteration
         for swap in iteration_swaps.iter() {

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -51,6 +51,44 @@ impl DacPuzzleSolver {
         *self.goal_array.get(idx).unwrap()
     }
 
+    fn solve_last_four_fields(&mut self) {
+        let last_fields_cycle = vec![
+            Coords {
+                row: self.height - 1,
+                col: self.width - 2,
+            },
+            Coords {
+                row: self.height - 2,
+                col: self.width - 2,
+            },
+            Coords {
+                row: self.height - 2,
+                col: self.width - 1,
+            },
+            Coords {
+                row: self.height - 1,
+                col: self.width - 1,
+            },
+        ];
+
+        let outer_last_field = last_fields_cycle[3];
+        let inner_last_field = last_fields_cycle[1];
+
+        // Ensure empty field is in position
+        if self.empty_field_pos != outer_last_field {
+            if self.empty_field_pos == inner_last_field {
+                self.apply_empty_field_moves_as_swaps(&[last_fields_cycle[0]]);
+            }
+
+            self.apply_empty_field_moves_as_swaps(&[outer_last_field]);
+        }
+
+        // Cycle last fields until we are in position
+        while self.fields != self.goal_array {
+            self.apply_empty_field_moves_as_swaps(&last_fields_cycle)
+        }
+    }
+
     pub fn solve_puzzle(&mut self) -> Vec<(usize, usize)> {
         let mut phase = SolverPhase::Row;
         let mut working_row = 0;
@@ -127,9 +165,6 @@ impl DacPuzzleSolver {
 
                     // Prepare next iteration step
                     working_col += 1;
-
-                    // TODO: Remove
-                    break 'row_col_loop;
                 }
             }
 
@@ -138,6 +173,9 @@ impl DacPuzzleSolver {
                 SolverPhase::Column => SolverPhase::Row,
             };
         }
+
+        self.solve_last_four_fields();
+
         self.swaps.clone()
     }
 

--- a/src/solver/divide_and_conquer.rs
+++ b/src/solver/divide_and_conquer.rs
@@ -1,0 +1,154 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::board::{get_empty_field_idx, get_row_col_from_idx, in_bounds};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Coords<T> {
+    row: T,
+    col: T,
+}
+
+pub fn move_first_in_place(fields: &mut [u8], width: usize, height: usize, field: u8) {
+    let width = width as i32;
+    let height = height as i32;
+
+    let target_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
+    let t_idx = target_array
+        .iter()
+        .position(|&v| v == field)
+        .expect("Should have field") as i32;
+    let (t_row, t_col) = get_row_col_from_idx(t_idx, width);
+
+    let mut empty_idx = get_empty_field_idx(&fields) as i32;
+    let mut field_idx = fields.iter().position(|&v| v == field).expect("Field") as i32;
+
+    loop {
+        let (e_row, e_col) = get_row_col_from_idx(empty_idx, width);
+        let (f_row, f_col) = get_row_col_from_idx(field_idx, width);
+
+        // Identify next field between field to move and target field
+        // For the upper row, move horizontal first
+        let d_col = t_col - f_col;
+        let d_row = t_row - f_row;
+
+        let (s_row, s_col) = identify_next_step_field_horiz_first(f_row, f_col, d_row, d_col);
+
+        let moves = compute_empty_field_moves(
+            Coords {
+                row: f_row,
+                col: f_col,
+            },
+            Coords {
+                row: s_row,
+                col: s_col,
+            },
+            Coords {
+                row: e_row,
+                col: e_col,
+            },
+            width,
+            height,
+        );
+        dbg!(moves);
+        break;
+
+        // Move empty field to that field without touching the field to move
+        // or already fixed fields
+
+        // Move through swaps
+    }
+}
+
+fn identify_next_step_field_horiz_first(
+    f_row: i32,
+    f_col: i32,
+    d_row: i32,
+    d_col: i32,
+) -> (i32, i32) {
+    // Move horizontal first
+    if d_col != 0 {
+        if d_col < 0 {
+            return (f_row, f_col - 1);
+        } else {
+            return (f_row, f_col + 1);
+        }
+    }
+
+    // d_row cannot be larger than zero because it would be in the ordered
+    // block otherwise
+    assert!(d_row <= 0);
+
+    if d_row != 0 {
+        return (f_row - 1, f_col);
+    } else {
+        return (f_row, f_col);
+    }
+}
+
+fn compute_empty_field_moves(
+    field: Coords<i32>,
+    step_field: Coords<i32>,
+    empty_field: Coords<i32>,
+    width: i32,
+    height: i32,
+) -> Vec<Coords<i32>> {
+    let mut forbidden_fields = HashSet::new();
+    forbidden_fields.insert(field);
+
+    let mut parent_field = HashMap::new();
+    let mut seen_neighbours: HashSet<Coords<i32>> = HashSet::new();
+    let mut to_discover = VecDeque::from([empty_field]);
+
+    // BFS from empty field until we find the step field
+    'expansion: while let Some(next_field) = to_discover.pop_front() {
+        seen_neighbours.insert(next_field);
+        let neighbours: Vec<Coords<i32>> = {
+            [(-1, 0), (1, 0), (0, 1), (0, -1)]
+                .iter()
+                .filter_map(|(d_row, d_col)| {
+                    let neighbour = Coords {
+                        row: next_field.row + d_row,
+                        col: next_field.col + d_col,
+                    };
+                    match in_bounds(neighbour.row, neighbour.col, width, height)
+                        && !seen_neighbours.contains(&neighbour)
+                        && !forbidden_fields.contains(&neighbour)
+                    {
+                        true => Some(neighbour),
+                        false => None,
+                    }
+                })
+                .collect()
+        };
+        for neighbour in neighbours {
+            parent_field.insert(neighbour, next_field);
+            to_discover.push_back(neighbour);
+            if neighbour == step_field {
+                break 'expansion;
+            }
+        }
+    }
+
+    // Trace back path and convert to swaps
+    let mut cur_field = step_field;
+    let mut parents = vec![cur_field];
+    while cur_field != empty_field {
+        let parent = *parent_field.get(&cur_field).expect("Should have parent");
+        parents.push(parent);
+        cur_field = parent;
+    }
+    parents.reverse();
+    parents
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_move_first_in_place() {
+        let mut test_fields = vec![8, 5, 6, 1, 0, 14, 7, 2, 255, 4, 11, 9, 12, 13, 10, 3];
+        move_first_in_place(&mut test_fields, 4, 4, 0);
+    }
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,0 +1,2 @@
+pub mod divide_and_conquer;
+pub mod optimal;

--- a/src/solver/optimal.rs
+++ b/src/solver/optimal.rs
@@ -1,12 +1,6 @@
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    sync::Arc,
-};
+use std::collections::{HashMap, VecDeque};
 
-use crate::board::{
-    get_empty_field_idx, get_row_col_from_idx, get_swappable_neighbours, in_bounds,
-    initialize_fields,
-};
+use crate::board::{get_empty_field_idx, get_swappable_neighbours, initialize_fields};
 
 pub trait AsStringHash<T> {
     fn as_string_hash(&self) -> String;
@@ -125,155 +119,10 @@ pub fn find_swap_order(fields: &[u8], width: usize, height: usize) -> Vec<(usize
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Coords<T> {
-    row: T,
-    col: T,
-}
-
-pub fn move_first_in_place(fields: &mut [u8], width: usize, height: usize, field: u8) {
-    let width = width as i32;
-    let height = height as i32;
-
-    let target_array: Vec<u8> = (0..(fields.len() as u8 - 1)).into_iter().collect();
-    let t_idx = target_array
-        .iter()
-        .position(|&v| v == field)
-        .expect("Should have field") as i32;
-    let (t_row, t_col) = get_row_col_from_idx(t_idx, width);
-
-    let mut empty_idx = get_empty_field_idx(&fields) as i32;
-    let mut field_idx = fields.iter().position(|&v| v == field).expect("Field") as i32;
-
-    loop {
-        let (e_row, e_col) = get_row_col_from_idx(empty_idx, width);
-        let (f_row, f_col) = get_row_col_from_idx(field_idx, width);
-
-        // Identify next field between field to move and target field
-        // For the upper row, move horizontal first
-        let d_col = t_col - f_col;
-        let d_row = t_row - f_row;
-
-        let (s_row, s_col) = identify_next_step_field_horiz_first(f_row, f_col, d_row, d_col);
-
-        let moves = compute_empty_field_moves(
-            Coords {
-                row: f_row,
-                col: f_col,
-            },
-            Coords {
-                row: s_row,
-                col: s_col,
-            },
-            Coords {
-                row: e_row,
-                col: e_col,
-            },
-            width,
-            height,
-        );
-        dbg!(moves);
-        break;
-
-        // Move empty field to that field without touching the field to move
-        // or already fixed fields
-
-        // Move through swaps
-    }
-}
-
-fn identify_next_step_field_horiz_first(
-    f_row: i32,
-    f_col: i32,
-    d_row: i32,
-    d_col: i32,
-) -> (i32, i32) {
-    // Move horizontal first
-    if d_col != 0 {
-        if d_col < 0 {
-            return (f_row, f_col - 1);
-        } else {
-            return (f_row, f_col + 1);
-        }
-    }
-
-    // d_row cannot be larger than zero because it would be in the ordered
-    // block otherwise
-    assert!(d_row <= 0);
-
-    if d_row != 0 {
-        return (f_row - 1, f_col);
-    } else {
-        return (f_row, f_col);
-    }
-}
-
-fn compute_empty_field_moves(
-    field: Coords<i32>,
-    step_field: Coords<i32>,
-    empty_field: Coords<i32>,
-    width: i32,
-    height: i32,
-) -> Vec<Coords<i32>> {
-    let mut forbidden_fields = HashSet::new();
-    forbidden_fields.insert(field);
-
-    let mut parent_field = HashMap::new();
-    let mut seen_neighbours: HashSet<Coords<i32>> = HashSet::new();
-    let mut to_discover = VecDeque::from([empty_field]);
-
-    // BFS from empty field until we find the step field
-    'expansion: while let Some(next_field) = to_discover.pop_front() {
-        seen_neighbours.insert(next_field);
-        let neighbours: Vec<Coords<i32>> = {
-            [(-1, 0), (1, 0), (0, 1), (0, -1)]
-                .iter()
-                .filter_map(|(d_row, d_col)| {
-                    let neighbour = Coords {
-                        row: next_field.row + d_row,
-                        col: next_field.col + d_col,
-                    };
-                    match in_bounds(neighbour.row, neighbour.col, width, height)
-                        && !seen_neighbours.contains(&neighbour)
-                        && !forbidden_fields.contains(&neighbour)
-                    {
-                        true => Some(neighbour),
-                        false => None,
-                    }
-                })
-                .collect()
-        };
-        for neighbour in neighbours {
-            parent_field.insert(neighbour, next_field);
-            to_discover.push_back(neighbour);
-            if neighbour == step_field {
-                break 'expansion;
-            }
-        }
-    }
-
-    // Trace back path and convert to swaps
-    let mut cur_field = step_field;
-    let mut parents = vec![cur_field];
-    while cur_field != empty_field {
-        let parent = *parent_field.get(&cur_field).expect("Should have parent");
-        parents.push(parent);
-        cur_field = parent;
-    }
-    parents.reverse();
-    parents
-}
-
 #[cfg(test)]
 mod test {
 
     use super::*;
-
-    #[test]
-    fn test_move_first_in_place() {
-        let mut test_fields = vec![8, 5, 6, 1, 0, 14, 7, 2, 255, 4, 11, 9, 12, 13, 10, 3];
-        move_first_in_place(&mut test_fields, 4, 4, 0);
-    }
 
     #[test]
     fn test_find_swap_order_zero_moves() {


### PR DESCRIPTION
This PR adds a solver based on the divide&conquer approach. It does not yield optimal solve orders, but it can solve even really big puzzles. E.g. a 6x6 would require the space of 3^30 ~= 2e14 states with the optimal brute-force solver which is PSPACE complete.