### PR TITLE
Switch hasher for states in optimal solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "slide-puzzle"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 getrandom = { version = "0.2.8", features = ["js"] }


### PR DESCRIPTION
The optimal solver had some forgotten left-over from the initial implementation: Instead of using a real hash function, it formatted the state to a string and used that as hash. The runtime was cut by >75% according to the benchmarks for the optimal solver.